### PR TITLE
Reverted to the CheckpointNumber for sorting in the GetFrom query, added...

### DIFF
--- a/src/NEventStore.Persistence.MongoDB/ExtensionMethods.cs
+++ b/src/NEventStore.Persistence.MongoDB/ExtensionMethods.cs
@@ -173,5 +173,12 @@
                          ).ToBsonDocument())
                     );
         }
+
+		public static bool DoesIndexHaveSameStructureAs(this MongoCollection<BsonDocument> collection, IndexKeysBuilder indexKeysBuilder, string indexNameToCheck)
+		{
+			var idxToCheck = collection.GetIndexes().SingleOrDefault(idx => idx.Name == indexNameToCheck);
+			// check the index string representation, it should be good enough for now
+			return (idxToCheck != null && idxToCheck.Key.ToString() != indexKeysBuilder.ToBsonDocument().ToString());			
+		}
     }
 }

--- a/src/NEventStore.Persistence.MongoDB/MongoPersistenceEngine.cs
+++ b/src/NEventStore.Persistence.MongoDB/MongoPersistenceEngine.cs
@@ -113,15 +113,22 @@
                     IndexOptions.SetName(MongoCommitIndexes.Dispatched).SetUnique(false)
                 );
 
-                PersistedCommits.CreateIndex(
-                    IndexKeys.Ascending(
-                            MongoCommitFields.BucketId,
-                            MongoCommitFields.StreamId,
+				// check the index structure to see if we need to drop it (update from a previous version)
+				var indexKeys = IndexKeys.Ascending(
+							MongoCommitFields.BucketId,
+							MongoCommitFields.StreamId,
 							MongoCommitFields.CheckpointNumber,
-                            MongoCommitFields.StreamRevisionFrom,
-                            MongoCommitFields.StreamRevisionTo
-                    //,MongoCommitFields.FullqualifiedStreamRevision
-                    ),
+							MongoCommitFields.StreamRevisionFrom,
+							MongoCommitFields.StreamRevisionTo
+					//,MongoCommitFields.FullqualifiedStreamRevision
+					);
+				if (PersistedCommits.DoesIndexHaveSameStructureAs(indexKeys, MongoCommitIndexes.GetFrom))
+				{
+					// I do not know a way to update an index, just drop it and recreate it (it can take some time too...)
+					PersistedCommits.DropIndexByName(MongoCommitIndexes.GetFrom);
+				}
+                PersistedCommits.CreateIndex(
+                    indexKeys,
                     IndexOptions.SetName(MongoCommitIndexes.GetFrom).SetUnique(true)
                 );
 


### PR DESCRIPTION
... the CheckpointNumber to the compound index that Mongo should use. This avoids the scanAndSort problem in query.
All the other queries that use same sorting scheme should benefit from this change too.
