### PR TITLE
Changed how the version number is getting populated in the build scripts

### DIFF
--- a/build/Build.RunTask.ps1
+++ b/build/Build.RunTask.ps1
@@ -1,6 +1,6 @@
 Param(
 	[string]$task,
-	[string]$version = "0.0.0.0",
+	[string]$buildNumber = "0",
 	[bool]$runPersistenceTests = $false)
 
 if($task -eq $null) {
@@ -10,4 +10,4 @@ if($task -eq $null) {
 $scriptPath = $(Split-Path -parent $MyInvocation.MyCommand.path)
 
 .$scriptPath\..\dependencies\RestorePackages.ps1
-.$scriptPath\..\dependencies\NEventStore\build\psake.ps1 -scriptPath $scriptPath -t $task -properties @{ version=$version;runPersistenceTests=$runPersistenceTests }
+.$scriptPath\..\dependencies\NEventStore\build\psake.ps1 -scriptPath $scriptPath -t $task -properties @{ build_number=$buildNumber;runPersistenceTests=$runPersistenceTests }

--- a/build/Modules/BuildFunctions.psm1
+++ b/build/Modules/BuildFunctions.psm1
@@ -1,0 +1,29 @@
+function Get-Version
+{
+	param
+	(
+		[string]$assemblyInfoFilePath
+	)
+	Write-Host "path $assemblyInfoFilePath"
+	$pattern = '(?<=^\[assembly\: AssemblyVersion\(\")(?<versionString>\d+\.\d+\.\d+\.\d+)(?=\"\))'
+	$assmblyInfoContent = Get-Content $assemblyInfoFilePath
+	return $assmblyInfoContent | Select-String -Pattern $pattern | Select -expand Matches |% {$_.Groups['versionString'].Value}
+}
+
+function Update-Version
+{
+	param
+    (
+		[string]$version,
+		[string]$assemblyInfoFilePath
+	)
+
+	$newVersion = 'AssemblyVersion("' + $version + '")';
+	$newFileVersion = 'AssemblyFileVersion("' + $version + '")';
+	$tmpFile = $assemblyInfoFilePath + ".tmp"
+
+	Get-Content $assemblyInfoFilePath |
+		%{$_ -replace 'AssemblyFileVersion\("[0-9]+(\.([0-9]+|\*)){1,3}"\)', $newFileVersion }  | Out-File -Encoding UTF8 $tmpFile
+
+	Move-Item $tmpFile $assemblyInfoFilePath -force
+}


### PR DESCRIPTION
Used how the core repo does it in an attempt to fix the assembly version not being populated.