### PR TITLE
Fix Purge(bucketId) to empty commits

### DIFF
--- a/src/NEventStore.Persistence.MongoDB/MongoPersistenceEngine.cs
+++ b/src/NEventStore.Persistence.MongoDB/MongoPersistenceEngine.cs
@@ -454,7 +454,7 @@
             {
                 PersistedStreamHeads.Remove(Query.EQ(MongoStreamHeadFields.FullQualifiedBucketId, bucketId));
                 PersistedSnapshots.Remove(Query.EQ(MongoShapshotFields.FullQualifiedBucketId, bucketId));
-                PersistedCommits.Remove(Query.EQ(MongoStreamHeadFields.FullQualifiedBucketId, bucketId));
+                PersistedCommits.Remove(Query.EQ(MongoCommitFields.BucketId, bucketId));
             });
 
         }


### PR DESCRIPTION
Purge was using "_id.BucketId" for all the queries.  Required format for Commits is just "BucketId", so no documents are removed from Commits on bucket specific Purge

The change was made by using git online fork and edit, I guess that's why it's marked everything as being changed.

The change was
PersistedCommits.Remove(Query.EQ(MongoStreamHeadFields.FullQualifiedBucketId, bucketId));
to
PersistedCommits.Remove(Query.EQ(MongoCommitFields.BucketId, bucketId));