### PR TITLE
Added the ability to configure the DictionaryRepresentation for the C…

### DIFF
--- a/src/NEventStore.Persistence.MongoDB.Tests/AcceptanceTestMongoPersistenceFactory.cs
+++ b/src/NEventStore.Persistence.MongoDB.Tests/AcceptanceTestMongoPersistenceFactory.cs
@@ -1,38 +1,46 @@
 ﻿namespace NEventStore.Persistence.MongoDB.Tests
 {
-    using System;
-    using NEventStore.Serialization;
+	using System;
+	using NEventStore.Serialization;
 
-    public class AcceptanceTestMongoPersistenceFactory : MongoPersistenceFactory
-    {
-        private const string EnvVarConnectionStringKey = "NEventStore.MongoDB";
-        private const string EnvVarServerSideLoopKey = "NEventStore.MongoDB.ServerSideLoop";
+	public class AcceptanceTestMongoPersistenceFactory : MongoPersistenceFactory
+	{
+		private const string EnvVarConnectionStringKey = "NEventStore.MongoDB";
+		private const string EnvVarServerSideLoopKey = "NEventStore.MongoDB.ServerSideLoop";
 
-        public AcceptanceTestMongoPersistenceFactory()
-            : base(
-                GetConnectionString,
-                new DocumentObjectSerializer(),
-                new MongoPersistenceOptions()
-            )
-        { }
+		public AcceptanceTestMongoPersistenceFactory()
+			: base(
+				GetConnectionString,
+				new DocumentObjectSerializer(),
+				new MongoPersistenceOptions()
+			)
+		{ }
 
-        private static string GetConnectionString()
-        {
-            string connectionString = Environment.GetEnvironmentVariable(EnvVarConnectionStringKey, EnvironmentVariableTarget.Process);
+		public AcceptanceTestMongoPersistenceFactory(MongoPersistenceOptions options)
+			: base(
+				GetConnectionString,
+				new DocumentObjectSerializer(),
+				options
+			)
+		{ }
 
-            if (connectionString == null)
-            {
-                string message = string.Format(
-                    "Cannot initialize acceptance tests for Mongo. Cannot find the '{0}' environment variable. Please ensure " +
-                    "you have correctly setup the connection string environment variables. Refer to the " +
-                    "NEventStore wiki for details.",
-                    EnvVarConnectionStringKey);
-                throw new InvalidOperationException(message);
-            }
+		private static string GetConnectionString()
+		{
+			string connectionString = Environment.GetEnvironmentVariable(EnvVarConnectionStringKey, EnvironmentVariableTarget.Process);
 
-            connectionString = connectionString.TrimStart('"').TrimEnd('"');
+			if (connectionString == null)
+			{
+				string message = string.Format(
+					"Cannot initialize acceptance tests for Mongo. Cannot find the '{0}' environment variable. Please ensure " +
+					"you have correctly setup the connection string environment variables. Refer to the " +
+					"NEventStore wiki for details.",
+					EnvVarConnectionStringKey);
+				throw new InvalidOperationException(message);
+			}
 
-            return connectionString;
-        }
-    }
+			connectionString = connectionString.TrimStart('"').TrimEnd('"');
+
+			return connectionString;
+		}
+	}
 }

--- a/src/NEventStore.Persistence.MongoDB.Tests/AcceptanceTests/CommitHeadersSerializationTests.cs
+++ b/src/NEventStore.Persistence.MongoDB.Tests/AcceptanceTests/CommitHeadersSerializationTests.cs
@@ -1,4 +1,6 @@
-﻿using NEventStore.Persistence.AcceptanceTests.BDD;
+﻿using MongoDB.Bson;
+using NEventStore.Persistence.AcceptanceTests;
+using NEventStore.Persistence.AcceptanceTests.BDD;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,38 +14,48 @@ namespace NEventStore.Persistence.MongoDB.Tests.AcceptanceTests
 	/// </summary>
 	public class when_serializing_headers_as_Document_and_a_commit_header_has_a_name_that_contains_a_period : SpecificationBase
 	{
-		private ICommit _persisted;
+		// private ICommit _persisted;
 		private string _streamId;
 		private IPersistStreams Persistence;
+
+		private Exception _thrown;
 
 		protected override void Context()
 		{
 			Persistence = new AcceptanceTestMongoPersistenceFactory(
-				new MongoPersistenceOptions {
-					CommitHeadersDictionaryRepresentation = 
-						global::MongoDB.Bson.Serialization.Options.DictionaryRepresentation.Document }
+				new MongoPersistenceOptions
+				{
+					CommitHeadersDictionaryRepresentation =
+						global::MongoDB.Bson.Serialization.Options.DictionaryRepresentation.Document
+				}
 				).Build();
-
-			_streamId = Guid.NewGuid().ToString();
-			var attempt = new CommitAttempt(_streamId,
-				2,
-				Guid.NewGuid(),
-				1,
-				DateTime.Now,
-				new Dictionary<string, object> { { "key.1", "value" } },
-				new List<EventMessage> { new EventMessage { Body = new NEventStore.Persistence.AcceptanceTests.ExtensionMethods.SomeDomainEvent { SomeProperty = "Test" } } });
-			Persistence.Commit(attempt);
 		}
 
 		protected override void Because()
 		{
-			_persisted = Persistence.GetFrom(_streamId, 0, int.MaxValue).First();
+			_thrown = Catch.Exception(() =>
+			{
+				_streamId = Guid.NewGuid().ToString();
+				var attempt = new CommitAttempt(_streamId,
+					2,
+					Guid.NewGuid(),
+					1,
+					DateTime.Now,
+					new Dictionary<string, object> { { "key.1", "value" } },
+					new List<EventMessage> { new EventMessage { Body = new NEventStore.Persistence.AcceptanceTests.ExtensionMethods.SomeDomainEvent { SomeProperty = "Test" } } });
+				Persistence.Commit(attempt);
+			});
+
+			// _persisted = Persistence.GetFrom(_streamId, 0, int.MaxValue).First();
 		}
 
 		[Fact]
-		public void should_correctly_deserialize_headers()
+		public void should_throw_serialization_exception_due_to_invalid_key()
 		{
-			_persisted.Headers.Keys.ShouldContain("key.1");
+			// _persisted.Headers.Keys.ShouldContain("key.1");
+
+			_thrown.ShouldBeInstanceOf<BsonSerializationException>();
+			_thrown.Message.ShouldContain("key.1");
 		}
 	}
 
@@ -95,9 +107,11 @@ namespace NEventStore.Persistence.MongoDB.Tests.AcceptanceTests
 		protected override void Context()
 		{
 			Persistence = new AcceptanceTestMongoPersistenceFactory(
-				new MongoPersistenceOptions {
-					CommitHeadersDictionaryRepresentation = 
-					global::MongoDB.Bson.Serialization.Options.DictionaryRepresentation.ArrayOfArrays }
+				new MongoPersistenceOptions
+				{
+					CommitHeadersDictionaryRepresentation =
+					global::MongoDB.Bson.Serialization.Options.DictionaryRepresentation.ArrayOfArrays
+				}
 				).Build();
 
 			_streamId = Guid.NewGuid().ToString();

--- a/src/NEventStore.Persistence.MongoDB.Tests/AcceptanceTests/CommitHeadersSerializationTests.cs
+++ b/src/NEventStore.Persistence.MongoDB.Tests/AcceptanceTests/CommitHeadersSerializationTests.cs
@@ -1,0 +1,125 @@
+﻿using NEventStore.Persistence.AcceptanceTests.BDD;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Should;
+
+namespace NEventStore.Persistence.MongoDB.Tests.AcceptanceTests
+{
+	/// <summary>
+	/// Be carefull! this test will fail with 'Catastrophic Failure' and Visual Studio IDE will report this as not run.
+	/// </summary>
+	public class when_serializing_headers_as_Document_and_a_commit_header_has_a_name_that_contains_a_period : SpecificationBase
+	{
+		private ICommit _persisted;
+		private string _streamId;
+		private IPersistStreams Persistence;
+
+		protected override void Context()
+		{
+			Persistence = new AcceptanceTestMongoPersistenceFactory(
+				new MongoPersistenceOptions {
+					CommitHeadersDictionaryRepresentation = 
+						global::MongoDB.Bson.Serialization.Options.DictionaryRepresentation.Document }
+				).Build();
+
+			_streamId = Guid.NewGuid().ToString();
+			var attempt = new CommitAttempt(_streamId,
+				2,
+				Guid.NewGuid(),
+				1,
+				DateTime.Now,
+				new Dictionary<string, object> { { "key.1", "value" } },
+				new List<EventMessage> { new EventMessage { Body = new NEventStore.Persistence.AcceptanceTests.ExtensionMethods.SomeDomainEvent { SomeProperty = "Test" } } });
+			Persistence.Commit(attempt);
+		}
+
+		protected override void Because()
+		{
+			_persisted = Persistence.GetFrom(_streamId, 0, int.MaxValue).First();
+		}
+
+		[Fact]
+		public void should_correctly_deserialize_headers()
+		{
+			_persisted.Headers.Keys.ShouldContain("key.1");
+		}
+	}
+
+	public class when_serializing_headers_as_Document_and_a_commit_header_has_a_valid_name : SpecificationBase
+	{
+		private ICommit _persisted;
+		private string _streamId;
+		private IPersistStreams Persistence;
+
+		protected override void Context()
+		{
+			Persistence = new AcceptanceTestMongoPersistenceFactory(
+				new MongoPersistenceOptions
+				{
+					CommitHeadersDictionaryRepresentation =
+						global::MongoDB.Bson.Serialization.Options.DictionaryRepresentation.Document
+				}
+				).Build();
+
+			_streamId = Guid.NewGuid().ToString();
+			var attempt = new CommitAttempt(_streamId,
+				2,
+				Guid.NewGuid(),
+				1,
+				DateTime.Now,
+				new Dictionary<string, object> { { "key", "value" } },
+				new List<EventMessage> { new EventMessage { Body = new NEventStore.Persistence.AcceptanceTests.ExtensionMethods.SomeDomainEvent { SomeProperty = "Test" } } });
+			Persistence.Commit(attempt);
+		}
+
+		protected override void Because()
+		{
+			_persisted = Persistence.GetFrom(_streamId, 0, int.MaxValue).First();
+		}
+
+		[Fact]
+		public void should_correctly_deserialize_headers()
+		{
+			_persisted.Headers.Keys.ShouldContain("key");
+		}
+	}
+
+	public class when_serializing_headers_as_ArrayOfArrays_and_a_commit_header_has_a_name_that_contains_a_period : SpecificationBase
+	{
+		private ICommit _persisted;
+		private string _streamId;
+		private IPersistStreams Persistence;
+
+		protected override void Context()
+		{
+			Persistence = new AcceptanceTestMongoPersistenceFactory(
+				new MongoPersistenceOptions {
+					CommitHeadersDictionaryRepresentation = 
+					global::MongoDB.Bson.Serialization.Options.DictionaryRepresentation.ArrayOfArrays }
+				).Build();
+
+			_streamId = Guid.NewGuid().ToString();
+			var attempt = new CommitAttempt(_streamId,
+				2,
+				Guid.NewGuid(),
+				1,
+				DateTime.Now,
+				new Dictionary<string, object> { { "key.1", "value" } },
+				new List<EventMessage> { new EventMessage { Body = new NEventStore.Persistence.AcceptanceTests.ExtensionMethods.SomeDomainEvent { SomeProperty = "Test" } } });
+			Persistence.Commit(attempt);
+		}
+
+		protected override void Because()
+		{
+			_persisted = Persistence.GetFrom(_streamId, 0, int.MaxValue).First();
+		}
+
+		[Fact]
+		public void should_correctly_deserialize_headers()
+		{
+			_persisted.Headers.Keys.ShouldContain("key.1");
+		}
+	}
+}

--- a/src/NEventStore.Persistence.MongoDB.Tests/NEventStore.Persistence.MongoDB.Tests.csproj
+++ b/src/NEventStore.Persistence.MongoDB.Tests/NEventStore.Persistence.MongoDB.Tests.csproj
@@ -38,6 +38,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="MongoDB.Bson, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.2.3\lib\net45\MongoDB.Bson.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -63,6 +67,7 @@
       <Link>Properties\VersionAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AcceptanceTestMongoPersistenceFactory.cs" />
+    <Compile Include="AcceptanceTests\CommitHeadersSerializationTests.cs" />
     <Compile Include="AcceptanceTests\OptimisticLoopTests.cs" />
     <Compile Include="AcceptanceTests\PersistenceEngineFixture.cs" />
     <Compile Include="AcceptanceTests\SharedPersistenceTests.cs" />
@@ -85,6 +90,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/NEventStore.Persistence.MongoDB.Tests/packages.config
+++ b/src/NEventStore.Persistence.MongoDB.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="MongoDB.Bson" version="2.2.3" targetFramework="net45" />
   <package id="xunit" version="1.9.1" targetFramework="net45" />
   <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
   <package id="xunit.should" version="1.1" targetFramework="net45" />

--- a/src/NEventStore.Persistence.MongoDB/DictionarySerializerSelector.cs
+++ b/src/NEventStore.Persistence.MongoDB/DictionarySerializerSelector.cs
@@ -1,0 +1,22 @@
+﻿using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Options;
+using MongoDB.Bson.Serialization.Serializers;
+using System.Collections.Generic;
+
+namespace NEventStore.Persistence.MongoDB
+{
+	/// <summary>
+	/// this is used in an extension method, so it should be passed as argument or cached in a static field
+	/// </summary>
+	internal static class DictionarySerializerSelector
+	{
+		internal static DictionaryRepresentation DictionaryRepresentation;
+		internal static IBsonSerializer DictionarySerializer;
+
+		public static void SetDictionaryRepresentation(DictionaryRepresentation dictionaryRepresentation)
+		{
+			DictionaryRepresentation = dictionaryRepresentation;
+			DictionarySerializer = new DictionaryInterfaceImplementerSerializer<Dictionary<string, object>>(DictionaryRepresentation);
+		}
+	}
+}

--- a/src/NEventStore.Persistence.MongoDB/ExtensionMethods.cs
+++ b/src/NEventStore.Persistence.MongoDB/ExtensionMethods.cs
@@ -32,7 +32,17 @@ namespace NEventStore.Persistence.MongoDB
             }
         }
 
-        public static BsonDocument ToMongoCommit(this CommitAttempt commit, LongCheckpoint checkpoint, IDocumentSerializer serializer)
+		/// <summary>
+		/// this extension method will use a predefined class <see cref="MongoCommit"/> with
+		/// serialization specified with Attributes.
+		/// 
+		/// todo: look if there's a was to modify the default serialization scheme so that the advanced user can customize the bahavior on her needs
+		/// </summary>
+		/// <param name="commit"></param>
+		/// <param name="checkpoint"></param>
+		/// <param name="serializer"></param>
+		/// <returns></returns>
+		public static BsonDocument ToMongoCommit_Experimental(this CommitAttempt commit, LongCheckpoint checkpoint, IDocumentSerializer serializer)
         {
             int streamRevision = commit.StreamRevision - (commit.Events.Count - 1);
             int streamRevisionStart = streamRevision;
@@ -62,7 +72,7 @@ namespace NEventStore.Persistence.MongoDB
             return mc.ToBsonDocument();
         }
 
-        public static BsonDocument ToxMongoCommit(this CommitAttempt commit, LongCheckpoint checkpoint, IDocumentSerializer serializer)
+        public static BsonDocument ToMongoCommit(this CommitAttempt commit, LongCheckpoint checkpoint, IDocumentSerializer serializer)
         {
             int streamRevision = commit.StreamRevision - (commit.Events.Count - 1);
             int streamRevisionStart = streamRevision;
@@ -83,9 +93,8 @@ namespace NEventStore.Persistence.MongoDB
                 {MongoCommitFields.CheckpointNumber, checkpoint.LongValue},
                 {MongoCommitFields.CommitId, commit.CommitId},
                 {MongoCommitFields.CommitStamp, commit.CommitStamp},
-                {MongoCommitFields.Headers, BsonDocumentWrapper.Create(commit.Headers)},
+                {MongoCommitFields.Headers, new BsonDocumentWrapper(commit.Headers, DictionarySerializerSelector.DictionarySerializer) }, // new BsonDocumentWrapper(commit.Headers, dictionarySerialize)},
                 {MongoCommitFields.Events, new BsonArray(events)},
-                {MongoCommitFields.Dispatched, false},
                 {MongoCommitFields.StreamRevisionFrom, streamRevisionStart},
                 {MongoCommitFields.StreamRevisionTo, streamRevision - 1},
                 {MongoCommitFields.BucketId, commit.BucketId},

--- a/src/NEventStore.Persistence.MongoDB/MongoPersistenceOptions.cs
+++ b/src/NEventStore.Persistence.MongoDB/MongoPersistenceOptions.cs
@@ -3,12 +3,13 @@
 	using System;
 	using global::MongoDB.Driver;
 	using NEventStore.Serialization;
+	using global::MongoDB.Bson.Serialization.Options;
 
 	/// <summary>
 	/// Options for the MongoPersistence engine.
 	/// http://docs.mongodb.org/manual/core/write-concern/#write-concern
 	/// </summary>
-	public  class MongoPersistenceOptions
+	public class MongoPersistenceOptions
 	{
 		/// <summary>
 		/// Get the  <see href="http://docs.mongodb.org/manual/core/write-concern/#write-concern">WriteConcern</see> for the commit insert operation.
@@ -49,7 +50,7 @@
 			};
 		}
 
-	    /// <summary>
+		/// <summary>
 		/// Connects to NEvenstore Mongo database
 		/// </summary>
 		/// <param name="connectionString">Connection string</param>
@@ -61,8 +62,20 @@
 			return database;
 		}
 
-	    public MongoPersistenceOptions()
-	    {
-	    }
+		/// <summary>
+		/// Select your serialization scheme for Commit.Headers dictionaty:
+		/// 
+		/// defaults to: DictionaryRepresentation.ArrayOfArrays 
+		/// </summary>
+		public DictionaryRepresentation CommitHeadersDictionaryRepresentation
+		{
+			get { return DictionarySerializerSelector.DictionaryRepresentation; }
+			set { DictionarySerializerSelector.SetDictionaryRepresentation(value); }
+		}
+
+		public MongoPersistenceOptions()
+		{
+			CommitHeadersDictionaryRepresentation = DictionaryRepresentation.ArrayOfArrays;
+		}
 	}
 }

--- a/src/NEventStore.Persistence.MongoDB/NEventStore.Persistence.MongoDB.csproj
+++ b/src/NEventStore.Persistence.MongoDB/NEventStore.Persistence.MongoDB.csproj
@@ -63,6 +63,7 @@
     <Compile Include="..\VersionAssemblyInfo.cs">
       <Link>Properties\VersionAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="DictionarySerializerSelector.cs" />
     <Compile Include="ExtensionMethods.cs" />
     <Compile Include="Messages.Designer.cs">
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
…ommit.Headers dictionary collection.

this is also a partial fix for: #31 because it restores the old way of building the Commit as a BSonDocument.
