### PR TITLE
Bug fix for issue 35

### DIFF
--- a/src/NEventStore.Persistence.MongoDB/MongoPersistenceEngine.cs
+++ b/src/NEventStore.Persistence.MongoDB/MongoPersistenceEngine.cs
@@ -543,7 +543,7 @@ namespace NEventStore.Persistence.MongoDB
                     {
                         Logger.Warn("Duplicate key exception {0} when upserting the stream head {1} {2}.", ex, bucketId, streamId);
                         
-                        retry = attempt > MaxAttempts;
+                        retry = attempt < MaxAttempts;
                     }
                 }
             });


### PR DESCRIPTION
Changed the way stream heads are updated to append to a in-memory queue.  Each thread attempts to start a poll of the queue (very similar to the PollingClient).

This ensures stream heads are written in the order they are queued which would then prevent upsert conflicts.

Also ensured that exceptions don't propagate and terminate the underlying process which was causing our messaging endpoints to terminate.  We don't use snapshots at the moment, so the benefit of the Streams table is minimal/nill from what I can see - plus a process termination would lose the stream head regardless.