### PR TITLE
Close issue #35

### DIFF
--- a/src/NEventStore.Persistence.MongoDB/NEventStore.Persistence.MongoDB.csproj
+++ b/src/NEventStore.Persistence.MongoDB/NEventStore.Persistence.MongoDB.csproj
@@ -56,9 +56,6 @@
     <Reference Include="System.Transactions" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\VersionAssemblyInfo.cs">
-      <Link>Properties\VersionAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="ExtensionMethods.cs" />
     <Compile Include="Messages.Designer.cs">
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
This is a proposal to close issue #35. Actually there is 
another pull request by @mikegore1000 but we think that
a simple try catch (without a retry) is the best solution for the issue.

Actually when UpdateStreamAsync is called with high load
and WiredTiger, it is possible that the update of stream
head throws a MongoDuplicateKeyException. In such a
situation we can safely ignore the error, because some
other thread already updated the record and we are not
able to know which is the latest one.