### PR TITLE
Changed _id index name

### DIFF
--- a/src/NEventStore.Persistence.MongoDB/MongoFields.cs
+++ b/src/NEventStore.Persistence.MongoDB/MongoFields.cs
@@ -48,7 +48,7 @@
 
     public static class MongoCommitIndexes
     {
-        public const string CheckpointNumber = "$_id_";
+        public const string CheckpointNumber = "_id_";
         public const string CommitStamp = "CommitStamp_Index";
         public const string GetFrom = "GetFrom_Index";
         public const string Dispatched = "Dispatched_Index";


### PR DESCRIPTION
With MongoDB switched to wired tiger we were getting unhandled exception inside "PersistWithClientSideOptimisticLoop" method when there was a MongoDuplicateKeyException. In this method there is already a error handler for this error ("E11000 duplicate key error collection: EventStore.Commits index: \_id\_ dup key: .....") but it was looking for an index name of "$\_id\_" here: 

```
  if (e.Message.Contains(MongoCommitIndexes.CheckpointNumber))
                        {
                            commitDoc[MongoCommitFields.CheckpointNumber] = _getNextCheckpointNumber().LongValue;
                        }

```
It looks the error message is slightly different in wired tiger than previously with MMap. 

My fix to the index name constant should work in both wired tiger and mmap.
