### PR TITLE
Hotfix/5.3.6 to fix issue #46

### DIFF
--- a/src/NEventStore.Persistence.MongoDB.Tests/packages.config
+++ b/src/NEventStore.Persistence.MongoDB.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="xunit" version="1.9.1" targetFramework="net45" />
+  <package id="xunit.runner.console" version="2.1.0" targetFramework="net45" />
   <package id="xunit.should" version="1.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Issue #46 was about error thrown during async update of Stream HEad. The solution could be simply to create a try catch around the entire call (including the TryMongo). 

I've also udpated xunit console runner and updated NES to a hotfix branch to be compatibile with the new build (that generates the numbering with gitversion.exe).