### PR TITLE
Bring back from develop check for duplicate id in WT

### DIFF
--- a/src/NEventStore.Persistence.MongoDB/MongoFields.cs
+++ b/src/NEventStore.Persistence.MongoDB/MongoFields.cs
@@ -48,7 +48,13 @@
 
     public static class MongoCommitIndexes
     {
-        public const string CheckpointNumber = "$_id_";
+        /// <summary>
+        /// the following value is used to determine the index
+        /// that throws exception when a duplicate is found.
+        /// </summary>
+        public const string CheckpointNumberMMApV1 = "$_id_";
+        public const string CheckpointNumberWiredTiger = "index: _id_";
+
         public const string CommitStamp = "CommitStamp_Index";
         public const string GetFrom = "GetFrom_Index";
         public const string Dispatched = "Dispatched_Index";

--- a/src/NEventStore.Persistence.MongoDB/MongoPersistenceEngine.cs
+++ b/src/NEventStore.Persistence.MongoDB/MongoPersistenceEngine.cs
@@ -334,7 +334,8 @@
                         }
 
                         // checkpoint index? 
-                        if (e.Message.Contains(MongoCommitIndexes.CheckpointNumber))
+                        if (e.Message.Contains(MongoCommitIndexes.CheckpointNumberMMApV1) ||
+                           e.Message.Contains(MongoCommitIndexes.CheckpointNumberWiredTiger))
                         {
                             commitDoc[MongoCommitFields.CheckpointNumber] = _getNextCheckpointNumber().LongValue;
                         }


### PR DESCRIPTION
In wired tiger the message associated to duplicate id is different
than MMapV1 so we need a double check to verify if an exception
is due to a violation of _id index.

This problem was already closed on develop and is bring down
to master.

This will also close pull request number 46, that also closes the very same 
problem but differently from develop.